### PR TITLE
[FIX] context for compute type 'distribution'. Elements based on parent elements, must be mapped to new copied ids.

### DIFF
--- a/customer_expense_account/models/expense_structure.py
+++ b/customer_expense_account/models/expense_structure.py
@@ -22,7 +22,13 @@ class ExpenseStructure(models.Model):
     def copy(self, default=None):
         default = dict(default or {})
         default['name'] = _('%s (copy)') % self.name
-        return super(ExpenseStructure, self).copy(default)
+        res = super(ExpenseStructure, self).copy(default)
+        # Elements based on parent elements, must be mapped to new copied ids
+        old_new_ids = dict(zip([x.id for x in self.element_ids],
+                               [x.id for x in res.element_ids]))
+        for element_id in res.element_ids.filtered(lambda r: r.parent_id):
+            element_id.parent_id = old_new_ids[element_id.parent_id.id]
+        return res
 
 
 class ExpenseStructureElements(models.Model):

--- a/customer_expense_account/models/expense_structure.py
+++ b/customer_expense_account/models/expense_structure.py
@@ -27,7 +27,8 @@ class ExpenseStructure(models.Model):
         old_new_ids = dict(zip([x.id for x in self.element_ids],
                                [x.id for x in res.element_ids]))
         for element_id in res.element_ids.filtered(lambda r: r.parent_id):
-            element_id.parent_id = old_new_ids[element_id.parent_id.id]
+            element_id.parent_id = old_new_ids.get(element_id.parent_id.id,
+                                                   False)
         return res
 
 

--- a/customer_expense_account/views/expense_structure_view.xml
+++ b/customer_expense_account/views/expense_structure_view.xml
@@ -63,7 +63,7 @@
                 <tree string="Expense Structure Elements"
                       colors="red:compute_type in ['total_cost', 'total_margin', 'total_sale', 'total_general'];
                               green:compute_type == 'invoicing';
-                              orange:compute_type == 'ratio';
+                              darkorange:compute_type == 'ratio';
                               blue:compute_type == 'distribution'">
                     <field name="sequence"/>
                     <field name="name"/>

--- a/customer_expense_account/views/expense_type_view.xml
+++ b/customer_expense_account/views/expense_type_view.xml
@@ -10,7 +10,7 @@
                 <tree string="Expense Types"
                       colors="red:compute_type in ['total_cost', 'total_margin', 'total_sale', 'total_general'];
                               green:compute_type == 'invoicing';
-                              orange:compute_type == 'ratio';
+                              darkorange:compute_type == 'ratio';
                               blue:compute_type == 'distribution'">
                     <field name="name"/>
                     <field name="compute_type"/>

--- a/customer_expense_account/wizard/customer_expense_wzd.py
+++ b/customer_expense_account/wizard/customer_expense_wzd.py
@@ -33,14 +33,10 @@ class CustomerExpenseWzd(models.TransientModel):
         structure = False
         model = self._context.get('active_model')
         if self._context.get('active_id', False):
-            if self._context.get('all_company', False):
-                structure = \
-                    self.env[model].browse(self._context['active_id']).\
-                    partner_id.structure_id
-            else:
-                structure = \
-                    self.env[model].browse(self._context['active_id']).\
-                    structure_id
+            structure = \
+                self.env[model].browse(self._context['active_id']).\
+                structure_id
+            if not self._context.get('all_company', False):
                 structure = structure or \
                     self.env[model].browse(self._context['active_id']).\
                     commercial_partner_id.structure_id
@@ -196,8 +192,10 @@ class ExpenseLine(models.TransientModel):
             elif e.compute_type == 'distribution':
                 var_ratio = self._get_var_ratio(partner, e,
                                                 e.ratio_compute_type)
+                ctx = {'from_date': self._context.get('from_date', False),
+                       'to_date': self._context.get('to_date', False)}
                 aac = e.expense_type_id.analytic_id
-                amount = aac.balance * (-1) * var_ratio
+                amount = aac.with_context(ctx).balance * (-1) * var_ratio
 
             # BASED ON TOTALIZATOR
             elif e.compute_type in ['total_cost', 'total_margin',

--- a/customer_expense_account/wizard/customer_expense_wzd_view.xml
+++ b/customer_expense_account/wizard/customer_expense_wzd_view.xml
@@ -45,7 +45,7 @@
                 <tree string="Expense Line"
                        colors="red:compute_type in ['total_cost', 'total_margin', 'total_sale', 'total_general'];
                                green:compute_type == 'invoicing';
-                               orange:compute_type == 'ratio';
+                               darkorange:compute_type == 'ratio';
                                blue:compute_type == 'distribution'">
                     <field name="name"/>
                     <field name="sales" attrs="{'invisible':[('sales','=',0)]}"/>


### PR DESCRIPTION
Established context for compute type 'distribution'.
Default value for structure when call from company.
When copy a structure, elements based on parent elements, must be mapped to new copied ids