### PR TITLE
[FIX]stock_picking_valued: Modificado cálculo precio de coste en movimientos, y precio unidad y total linea en las operaciones

### DIFF
--- a/stock_picking_valued/models/stock.py
+++ b/stock_picking_valued/models/stock.py
@@ -51,7 +51,6 @@ class stock_picking(models.Model):
     @api.depends('move_lines', 'partner_id')
     def _amount_all(self):
         for picking in self:
-            print picking
             taxes = amount_gross = amount_untaxed = 0.0
             cur = picking.partner_id.property_product_pricelist \
                 and picking.partner_id.property_product_pricelist.currency_id \
@@ -148,18 +147,12 @@ class StockPackOperation(models.Model):
 
     price_unit = fields.Float(
         compute='_get_subtotal', string="Price unit",
-        digits=dp.get_precision('Product Price'), readonly=True,
-        store=True)
+        digits=dp.get_precision('Product Price'), readonly=True)
     price_subtotal = fields.Float(
         compute='_get_subtotal', string="Subtotal",
-        digits=dp.get_precision('Account'), readonly=True,
-        store=True)
+        digits=dp.get_precision('Account'), readonly=True)
 
     @api.multi
-    @api.depends('product_qty',
-                 'linked_move_operation_ids.move_id.product_id',
-                 'linked_move_operation_ids.move_id.product_uom_qty',
-                 'linked_move_operation_ids.move_id.procurement_id.sale_line_id')
     def _get_subtotal(self):
         for operation in self:
             subtotal = 0.0

--- a/stock_picking_valued/views/valued_picking_report.xml
+++ b/stock_picking_valued/views/valued_picking_report.xml
@@ -97,8 +97,7 @@
                                                     </t>
                                                 </td>
                                                 <td class="text-right" t-if="o.valued_picking == True and o.picking_type_id.code == 'outgoing'"><span
-                                                        t-field="move.order_price_unit"
-                                                        t-field-options='{"widget": "monetary", "display_currency": "o.sale_id.pricelist_id.currency_id"}'/></td>
+                                                        t-field="move.order_price_unit"/></td>
                                                 <td class="text-right" t-if="o.valued_picking == True and o.picking_type_id.code == 'outgoing'">
                                                     <span t-field="move.price_subtotal"
                                                         t-field-options='{"widget": "monetary", "display_currency": "o.sale_id.pricelist_id.currency_id"}'/>
@@ -116,8 +115,7 @@
                                                 </td>
                                                 <td class="text-right"><span t-field="operation.lot_id"/></td>
                                                 <td class="text-right" t-if="o.valued_picking == True and o.picking_type_id.code == 'outgoing'"><span
-                                                        t-field="operation.price_unit"
-                                                        t-field-options='{"widget": "monetary", "display_currency": "o.sale_id.pricelist_id.currency_id"}'/>
+                                                        t-field="operation.price_unit"/>
                                                 </td>
                                                 <td class="text-right" t-if="o.valued_picking == True and o.picking_type_id.code == 'outgoing'">
                                                     <span t-field="operation.price_subtotal"

--- a/stock_picking_valued/views/valued_picking_report.xml
+++ b/stock_picking_valued/views/valued_picking_report.xml
@@ -116,7 +116,7 @@
                                                 </td>
                                                 <td class="text-right"><span t-field="operation.lot_id"/></td>
                                                 <td class="text-right" t-if="o.valued_picking == True and o.picking_type_id.code == 'outgoing'"><span
-                                                        t-field="operation.linked_move_operation_ids[0].move_id.order_price_unit"
+                                                        t-field="operation.price_unit"
                                                         t-field-options='{"widget": "monetary", "display_currency": "o.sale_id.pricelist_id.currency_id"}'/>
                                                 </td>
                                                 <td class="text-right" t-if="o.valued_picking == True and o.picking_type_id.code == 'outgoing'">


### PR DESCRIPTION
Se propone cambiar los siguiente:

1. Para el cálculo del precio de coste en los movimientos (cost_subtotal):
Se obtiene el precio de coste del histórico de precios en la fecha de transferencia. De esta forma si se vuelve a disparar la función se obtendrá el coste en función del coste del producto en ese momento.
Si no existiese se obtendría directamente del producto (standard_price), pero teniendo en cuenta la compañía del movimiento (with_context), pues sino al instalar en una base de datos en producción y multicompañía usaría el coste de la compañía del superusuario, o incluso en el uso normal al llamar al write por ejemplo con sudo().

2. Para el cálculo del precio total en las operaciones (price_subtotal):
Se modifica el método de cálculo pues era incorrecto poner como precio unitario el del movimiento y como subtotal el correspondiente a la cantidad de la operación (se crea un nuevo campo price_unit). Solo sería correcto si hubiese una linea de venta por producto o varias pero al mismo precio. Si por ejemplo hay dos lineas del mismo producto, y una de ellas a precio 0 (mercancía sin cargo) se mostraría incorrectamente. Esto provoca un problema añadido que se podría intentar resolver de alguna forma en este PR. Es el caso de un extra move. Tal como está el PR sería tratado a precio 0, lo cual influiría sobre el precio unitario, rebajándolo.

3. Se cambia en depends: linked_move_operation_ids.move_id.price_subtotal por los mismos depends de la función que calcula 'price_subtotal'
Actualmente en una base de datos de referencia con 175000 registros en stock_pack_operation tarda en actualizarse aprox 2h40m, teniendo como depends 'linked_move_operation_ids.move_id.price_subtotal', ó aprox 50m si se cambia por los mismos depends de la función que calcula 'price_subtotal' en stock_move (tal como está en el PR). No entiendo el por qué, pero la diferencia es notable y creo que seguirá disparándose el cálculo correctamente.

4. No está así en el PR, pero creo que se podrían hacer los campos price_subtotal y price_unit de stock_pack_operation con store=False. 


