### PR TITLE
[11.0] Redondeo al comprobar pago anticipado con el residual

### DIFF
--- a/purchase_advance_payment/wizard/purchase_advance_payment_wzd.py
+++ b/purchase_advance_payment/wizard/purchase_advance_payment_wzd.py
@@ -42,7 +42,7 @@ class AccountVoucherWizard(models.TransientModel):
         if self.env.context.get('active_id', False):
             order = self.env["purchase.order"].\
                 browse(self.env.context['active_id'])
-            if self.amount_advance > order.amount_resisual:
+            if self.amount_advance > round(order.amount_resisual, 2):
                 raise exceptions.ValidationError(_("Amount of advance is "
                                                    "greater than residual "
                                                    "amount on purchase"))

--- a/purchase_advance_payment/wizard/purchase_advance_payment_wzd.py
+++ b/purchase_advance_payment/wizard/purchase_advance_payment_wzd.py
@@ -42,7 +42,7 @@ class AccountVoucherWizard(models.TransientModel):
         if self.env.context.get('active_id', False):
             order = self.env["purchase.order"].\
                 browse(self.env.context['active_id'])
-            if self.amount_advance > round(order.amount_resisual, 2):
+            if round(self.amount_advance, 2) > round(order.amount_resisual, 2):
                 raise exceptions.ValidationError(_("Amount of advance is "
                                                    "greater than residual "
                                                    "amount on purchase"))

--- a/sale_advance_payment/wizard/sale_advance_payment_wzd.py
+++ b/sale_advance_payment/wizard/sale_advance_payment_wzd.py
@@ -57,7 +57,7 @@ class AccountVoucherWizard(models.TransientModel):
         if self.env.context.get('active_id', False):
             order = self.env["sale.order"].\
                 browse(self.env.context['active_id'])
-            if self.amount_advance > order.amount_resisual:
+            if self.amount_advance > round(order.amount_resisual, 2):
                 raise exceptions.ValidationError(_("Amount of advance is "
                                                    "greater than residual "
                                                    "amount on sale"))

--- a/sale_advance_payment/wizard/sale_advance_payment_wzd.py
+++ b/sale_advance_payment/wizard/sale_advance_payment_wzd.py
@@ -57,7 +57,7 @@ class AccountVoucherWizard(models.TransientModel):
         if self.env.context.get('active_id', False):
             order = self.env["sale.order"].\
                 browse(self.env.context['active_id'])
-            if self.amount_advance > round(order.amount_resisual, 2):
+            if round(self.amount_advance, 2) > round(order.amount_resisual, 2):
                 raise exceptions.ValidationError(_("Amount of advance is "
                                                    "greater than residual "
                                                    "amount on sale"))


### PR DESCRIPTION
[FIX] purchase_advance_payment, sale_advance_payment: Redondeo de la cantidad pendiente de pagar para evitar diferencias a partir del tercer decimal que impedían, en muchos casos, registrar un pago
