### PR TITLE
[13.0][IMP] account_due_list_payment_mode_edit: modo de pago seleccionable según el tipo de efecto

### DIFF
--- a/account_due_list_payment_mode_edit/__manifest__.py
+++ b/account_due_list_payment_mode_edit/__manifest__.py
@@ -1,11 +1,14 @@
 {
     "name": "Account Due List Payment mode editable",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.1.0",
     "author": "Comunitea",
     "website": "https://www.comunitea.com",
     "description": "Account Due List Improvements",
     "depends": ['account_due_list_payment_mode'],
-    "data": ['views/account_move.xml'],
+    "data": [
+        'views/account_move.xml',
+        'views/account_move_line.xml',
+    ],
     "installable": True,
     'license': 'AGPL-3'
 }

--- a/account_due_list_payment_mode_edit/models/account_move_line.py
+++ b/account_due_list_payment_mode_edit/models/account_move_line.py
@@ -1,5 +1,9 @@
 from odoo import fields, models
 
+PAYMENT_MODE_MAPPING = {
+    "payable": "outbound",
+    "receivable": "inbound",
+}
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
@@ -7,3 +11,17 @@ class AccountMoveLine(models.Model):
     payment_mode_id = fields.Many2one(
         readonly=False,
     )
+
+    payment_mode_type = fields.Char(
+        compute="_compute_payment_mode_type",
+        help="""
+        Technical field that enables payment mode restricted selection
+        depending on due type (payable or receivable)
+        """,
+    )
+
+    def _compute_payment_mode_type(self):
+        for move_line in self:
+            move_line.payment_mode_type = PAYMENT_MODE_MAPPING.get(
+                move_line.account_internal_type, "other"
+            )

--- a/account_due_list_payment_mode_edit/views/account_move_line.xml
+++ b/account_due_list_payment_mode_edit/views/account_move_line.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="account_move_line_payments" model="ir.ui.view">
+        <field name="name">account.move.line.payments</field>
+        <field name="model">account.move.line</field>
+        <field
+            name="inherit_id"
+            ref="account_payment_partner.view_move_line_form"
+        />
+        <field name="arch" type="xml">
+            <field name="payment_mode_id" position="before">
+                <field name="payment_mode_type" invisible="1"/>
+            </field>
+            <field name="payment_mode_id" position="attributes">
+                <attribute name="domain">[('payment_type', '=', payment_mode_type)]</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Al ser modificable el modo de pago, con esta mejora, en función del tipo de efecto, ya solo se ofrecen los modos de pago (saliente, entrante o ninguno) que corresponda.

@omar7r vamos a instalar en el cliente con esta modificación añadida, si es posible incorporad esto a vuestro repo por si toca evolucionar el módulo en el futuro.

Gracias!

cc @lmiguens-solvos
